### PR TITLE
Updates to zig 0.8

### DIFF
--- a/src/builder.zig
+++ b/src/builder.zig
@@ -7,26 +7,26 @@ pub fn main() u8 {
     const builder: *GtkBuilder = gtk_builder_new();
     var err: [*c]GError = null;
 
-    // Construct a GtkBuilder instance and load our UI description 
+    // Construct a GtkBuilder instance and load our UI description
     if (gtk_builder_add_from_file(builder, "src/builder.ui", &err) == 0) {
         g_printerr("Error loading file: %s\n", err.*.message);
         g_clear_error(&err);
         return 1;
     }
 
-    // Connect signal handlers to the constructed widgets. 
+    // Connect signal handlers to the constructed widgets.
     const window = gtk_builder_get_object(builder, "window");
 
-    _ = g_signal_connect(window, "destroy", @ptrCast(GCallback, gtk_main_quit), null);
+    _ = g_signal_connect_(window, "destroy", @ptrCast(GCallback, gtk_main_quit), null);
 
     var button = gtk_builder_get_object(builder, "button1");
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, print_hello), null);
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, print_hello), null);
 
-    button = gtk_builder_get_object (builder, "button2");
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, print_hello), null);
+    button = gtk_builder_get_object(builder, "button2");
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, print_hello), null);
 
-    button = gtk_builder_get_object (builder, "quit");
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, gtk_main_quit), null);
+    button = gtk_builder_get_object(builder, "quit");
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, gtk_main_quit), null);
 
     gtk_main();
 

--- a/src/embedded.zig
+++ b/src/embedded.zig
@@ -11,29 +11,29 @@ pub fn main() u8 {
 
     var bdp: [*c]const u8 = builderDecl;
 
-    // Construct a GtkBuilder instance and load our UI description 
+    // Construct a GtkBuilder instance and load our UI description
     if (gtk_builder_add_from_string(builder, bdp, builderDecl.len, &err) == 0) {
         g_printerr("Error loading embedded builder: %s\n", err.*.message);
         g_clear_error(&err);
         return 1;
     }
 
-    // Connect signal handlers to the constructed widgets. 
+    // Connect signal handlers to the constructed widgets.
     const window = gtk_builder_get_object(builder, "window");
 
     var zero: u32 = 0;
     const flags: *GConnectFlags = @ptrCast(*GConnectFlags, &zero);
 
-    _ = g_signal_connect(window, "destroy", @ptrCast(GCallback, gtk_main_quit), null);
+    _ = g_signal_connect_(window, "destroy", @ptrCast(GCallback, gtk_main_quit), null);
 
     var button = gtk_builder_get_object(builder, "button1");
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, print_hello), null);
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, print_hello), null);
 
-    button = gtk_builder_get_object (builder, "button2");
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, print_hello), null);
+    button = gtk_builder_get_object(builder, "button2");
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, print_hello), null);
 
-    button = gtk_builder_get_object (builder, "quit");
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, gtk_main_quit), null);
+    button = gtk_builder_get_object(builder, "quit");
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, gtk_main_quit), null);
 
     gtk_main();
 

--- a/src/gtk.zig
+++ b/src/gtk.zig
@@ -3,17 +3,17 @@ pub usingnamespace @cImport({
 });
 
 pub fn print_hello(widget: *GtkWidget, data: gpointer) void {
-    g_print ("Hello World\n");
+    g_print("Hello World\n");
 }
 
 /// Could not get `g_signal_connect` to work. Zig says "use of undeclared identifier". Reimplemented here
-pub fn g_signal_connect(instance: gpointer, detailed_signal: [*c]const gchar, c_handler: GCallback, data: gpointer) gulong {
+pub fn g_signal_connect_(instance: gpointer, detailed_signal: [*c]const gchar, c_handler: GCallback, data: gpointer) gulong {
     var zero: u32 = 0;
     const flags: *GConnectFlags = @ptrCast(*GConnectFlags, &zero);
     return g_signal_connect_data(instance, detailed_signal, c_handler, null, null, flags.*);
 }
 
 /// Could not get `g_signal_connect_swapped` to work. Zig says "use of undeclared identifier". Reimplemented here
-pub fn g_signal_connect_swapped(instance: gpointer, detailed_signal: [*c]const gchar, c_handler: GCallback, data: gpointer) gulong {
+pub fn g_signal_connect_swapped_(instance: gpointer, detailed_signal: [*c]const gchar, c_handler: GCallback, data: gpointer) gulong {
     return g_signal_connect_data(instance, detailed_signal, c_handler, data, null, .G_CONNECT_SWAPPED);
 }

--- a/src/manual.zig
+++ b/src/manual.zig
@@ -8,8 +8,8 @@ fn activate(app: *GtkApplication, user_data: gpointer) void {
 
     const button: *GtkWidget = gtk_button_new_with_label("Hello World");
 
-    _ = g_signal_connect(button, "clicked", @ptrCast(GCallback, print_hello), null);
-    _ = g_signal_connect_swapped(button, "clicked", @ptrCast(GCallback, gtk_widget_destroy), window);
+    _ = g_signal_connect_(button, "clicked", @ptrCast(GCallback, print_hello), null);
+    _ = g_signal_connect_swapped_(button, "clicked", @ptrCast(GCallback, gtk_widget_destroy), window);
     gtk_container_add(@ptrCast(*GtkContainer, button_box), button);
 
     const w = @ptrCast(*GtkWindow, window);
@@ -22,7 +22,7 @@ pub fn main() u8 {
     var app = gtk_application_new("org.gtk.example", .G_APPLICATION_FLAGS_NONE);
     defer g_object_unref(app);
 
-    _ = g_signal_connect(app, "activate", @ptrCast(GCallback, activate), null);
+    _ = g_signal_connect_(app, "activate", @ptrCast(GCallback, activate), null);
     const status: i32 = g_application_run(@ptrCast(*GApplication, app), 0, null);
 
     return @intCast(u8, status);


### PR DESCRIPTION
Hi. I tried your examples with latest compiler on Manjaro and got some erros.
Now zig understand C macro but failed with some errors about unacceptable casts if your functions are commented out.
So I still use your functions, just renamed the functions to avoid redifinitions. 
And I runned `zig fmt src/builder.zig src/embedded.zig src/gtk.zig src/manual.zig`

Thank you for the examples!