### PR TITLE
Update to zig 0.9.0 (nightly)

### DIFF
--- a/src/embedded.zig
+++ b/src/embedded.zig
@@ -24,6 +24,8 @@ pub fn main() u8 {
     var zero: u32 = 0;
     const flags: *GConnectFlags = @ptrCast(*GConnectFlags, &zero);
 
+    _ = flags;
+
     _ = g_signal_connect_(window, "destroy", @ptrCast(GCallback, gtk_main_quit), null);
 
     var button = gtk_builder_get_object(builder, "button1");

--- a/src/gtk.zig
+++ b/src/gtk.zig
@@ -3,11 +3,14 @@ pub usingnamespace @cImport({
 });
 
 pub fn print_hello(widget: *GtkWidget, data: gpointer) void {
+    _ = data;
+    _ = widget;
     g_print("Hello World\n");
 }
 
 /// Could not get `g_signal_connect` to work. Zig says "use of undeclared identifier". Reimplemented here
 pub fn g_signal_connect_(instance: gpointer, detailed_signal: [*c]const gchar, c_handler: GCallback, data: gpointer) gulong {
+    _ = data;
     var zero: u32 = 0;
     const flags: *GConnectFlags = @ptrCast(*GConnectFlags, &zero);
     return g_signal_connect_data(instance, detailed_signal, c_handler, null, null, flags.*);
@@ -15,5 +18,5 @@ pub fn g_signal_connect_(instance: gpointer, detailed_signal: [*c]const gchar, c
 
 /// Could not get `g_signal_connect_swapped` to work. Zig says "use of undeclared identifier". Reimplemented here
 pub fn g_signal_connect_swapped_(instance: gpointer, detailed_signal: [*c]const gchar, c_handler: GCallback, data: gpointer) gulong {
-    return g_signal_connect_data(instance, detailed_signal, c_handler, data, null, .G_CONNECT_SWAPPED);
+    return g_signal_connect_data(instance, detailed_signal, c_handler, data, null, G_CONNECT_SWAPPED);
 }

--- a/src/manual.zig
+++ b/src/manual.zig
@@ -1,9 +1,10 @@
 pub usingnamespace @import("gtk.zig");
 
 fn activate(app: *GtkApplication, user_data: gpointer) void {
+    _ = user_data;
     const window: *GtkWidget = gtk_application_window_new(app);
 
-    const button_box: *GtkWidget = gtk_button_box_new(.GTK_ORIENTATION_HORIZONTAL);
+    const button_box: *GtkWidget = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
     gtk_container_add(@ptrCast(*GtkContainer, window), button_box);
 
     const button: *GtkWidget = gtk_button_new_with_label("Hello World");
@@ -19,7 +20,7 @@ fn activate(app: *GtkApplication, user_data: gpointer) void {
 }
 
 pub fn main() u8 {
-    var app = gtk_application_new("org.gtk.example", .G_APPLICATION_FLAGS_NONE);
+    var app = gtk_application_new("org.gtk.example", G_APPLICATION_FLAGS_NONE);
     defer g_object_unref(app);
 
     _ = g_signal_connect_(app, "activate", @ptrCast(GCallback, activate), null);


### PR DESCRIPTION
These little changes allow ziggtk to build with zig 0.9.0, precisely `zig-macos-aarch64-0.9.0-dev.685+e5e6ceda6`.